### PR TITLE
feat(Browsing Issues): added functionality to favorite projects

### DIFF
--- a/app/renderer/containers/Sidebar/IssuesSourcePicker/styled/index.jsx
+++ b/app/renderer/containers/Sidebar/IssuesSourcePicker/styled/index.jsx
@@ -12,3 +12,11 @@ export const InputLabel = styled.span`
   font-weight: 600;
   margin-bottom: 4px;
 `;
+
+export const SingleSelectContainer = styled.div`
+  flex: 1;
+`;
+
+export const FavoriteIcon = styled.div`
+  cursor: pointer;
+`;

--- a/app/renderer/reducers/index.js
+++ b/app/renderer/reducers/index.js
@@ -106,6 +106,7 @@ const rootReducer = combineReducers({
     initialState: {
       lists: {
         allProjects: [],
+        favorites: [],
       },
     },
   }),

--- a/app/renderer/sagas/helpers.js
+++ b/app/renderer/sagas/helpers.js
@@ -3,6 +3,7 @@ import storage from 'electron-json-storage';
 
 import {
   getUiState,
+  getResourceIds,
 } from 'selectors';
 import {
   persistInitialState as persistInitialUiState,
@@ -118,5 +119,14 @@ export function* savePersistStorage() {
     setElectronStorage,
     'accounts',
     accounts,
+  );
+
+  const favoriteProjects = yield eff.select(
+    getResourceIds('projects', 'favorites'),
+  );
+  yield eff.call(
+    setElectronStorage,
+    'projects_favorites',
+    favoriteProjects,
   );
 }

--- a/app/renderer/sagas/initialize.js
+++ b/app/renderer/sagas/initialize.js
@@ -29,6 +29,8 @@ import {
   issuesActions,
   updaterActions,
 } from 'actions';
+import createActionCreators from 'redux-resource-action-creators';
+
 import config from 'config';
 import {
   getPreload,
@@ -247,7 +249,7 @@ function* issueWindow(url) {
   }
 }
 
-export function* takeInitialConfigureApp() {
+export function* takeInitialConfigureApp(): Generator<*, *, *> {
   let issueWindowTask = null;
   while (true) {
     const {
@@ -307,6 +309,20 @@ export function* takeInitialConfigureApp() {
         ...persistUiState,
         accounts,
       }));
+
+      const favoriteProjects = yield eff.call(
+        getElectronStorage,
+        'projects_favorites',
+        [],
+      );
+      yield eff.put(
+        createActionCreators('update', {
+          resourceType: 'projects',
+          resources: favoriteProjects,
+          list: 'favorites',
+          mergeListIds: true,
+        }).succeeded(),
+      );
 
       yield eff.put(updaterActions.setUpdateSettings({
         autoDownload: persistUiState.updateAutomatically,

--- a/app/renderer/selectors/issues.js
+++ b/app/renderer/selectors/issues.js
@@ -304,15 +304,22 @@ export const getTrackingIssueReport = createSelector(
 
 export const getIssuesSourceOptions = createSelector(
   [
+    getResourceMappedList('projects', 'favorites'),
     getResourceMappedList('projects', 'allProjects'),
     getResourceMappedList('boards', 'allBoards'),
     getResourceMappedList('filters', 'allFilters'),
   ],
   (
+    favoriteProjects: Array<Project>,
     projects: Array<Project>,
     boards: Array<Board>,
     filters: Array<JIRAFilter>,
   ) => [
+    {
+      heading: 'Favorite Projects',
+      items: favoriteProjects.map(project =>
+        ({ value: project.id, content: `${project.name}(${project.key})`, meta: { project } })),
+    },
     {
       heading: 'Projects',
       items: projects.map(project =>


### PR DESCRIPTION
Users now have the ability to favorite projects! A star-icon is present next to the
IssueSourcePicker and there is also a new category called 'Favorite Projects' which contains a
section of all favorite projects for the user to scroll through. The section appears before the rest
to give users an easier time finding favorite projects.
Favorites are also persisted to electron
storage on quit and reloaded whenever the app is restarted.
This only works for projects at the
moments but can be used for filters or other issueSourceTypes later.

ISSUES CLOSED: #47